### PR TITLE
TICKET-20: Refresh Poll Results

### DIFF
--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModal.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModal.tsx
@@ -140,7 +140,14 @@ export default function ResultsModal({ isOpen, onClose, pollID }: ResultsModalPr
 
       setLoading(false);
     };
-    getResults();
+
+    const interval = setInterval(() => {
+      getResults();
+    }, 5000);
+
+    return () => {
+      clearInterval(interval);
+    };
   }, [coveyTownController, pollID, getResultsDisplay]);
 
   return (


### PR DESCRIPTION
closes #16 

## Changes

- added `setInterval` to the `useEffect` hook in the `ResultsModal`, so that the get results API gets called and the UI on the modal gets updated every 5 seconds.
- this approach is a better user experience than having a refresh button, as results will auto-update for the user
- guide used: https://rapidapi.com/guides/api-requests-intervals