### PR TITLE
Add support for long options

### DIFF
--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalContent.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalContent.tsx
@@ -39,6 +39,7 @@ export default function ResultsModalContent({
               index={index}
               accordion={false}
               yourVote={yourVote}
+              anonymous={anonymous}
             />
           </div>
         ))}
@@ -56,6 +57,7 @@ export default function ResultsModalContent({
               index={index}
               accordion={true}
               yourVote={yourVote}
+              anonymous={anonymous}
             />
           </AccordionButton>
           <AccordionPanel style={{ padding: '0.5rem 1rem 0.5rem 1rem' }}>

--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
@@ -90,7 +90,7 @@ export default function ResultsModalOption({
           backgroundColor: youVotedFor ? 'rgba(49, 130, 206, 0.75)' : 'rgba(49, 130, 206, 0.20)',
         }}
         className={classes.bar}></div>
-      <div className={classes.leftSide} style={{ marginRight: anonymous ? '4.5rem' : '6rem' }}>
+      <div className={classes.leftSide} style={{ marginRight: anonymous ? '4.5rem' : '6.25rem' }}>
         <div className={classes.optionText}>{result.option}</div>
         {youVotedFor && (
           <div className={classes.checkmark}>

--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
@@ -91,7 +91,7 @@ export default function ResultsModalOption({
           backgroundColor: youVotedFor ? 'rgba(49, 130, 206, 0.75)' : 'rgba(49, 130, 206, 0.20)',
         }}
         className={classes.bar}></div>
-      <div className={classes.leftSide} style={{ width: anonymous ? '77%' : '70%' }}>
+      <div className={classes.leftSide} style={{ marginRight: anonymous ? '4.5rem' : '6rem' }}>
         <div className={classes.optionText}>{result.option}</div>
         {youVotedFor && (
           <div className={classes.checkmark}>

--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles({
     fontWeight: 700,
     color: 'black',
     textAlign: 'left',
-    whiteSpace: 'normal',
     overflowWrap: 'anywhere',
   },
   checkmark: {

--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/Results/ResultsModalOption.tsx
@@ -8,6 +8,7 @@ interface ResultsModalOptionProps {
   index: number;
   accordion: boolean;
   yourVote: number[];
+  anonymous: boolean;
 }
 
 const useStyles = makeStyles({
@@ -40,6 +41,9 @@ const useStyles = makeStyles({
     fontSize: '1rem',
     fontWeight: 700,
     color: 'black',
+    textAlign: 'left',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   },
   checkmark: {
     marginLeft: '0.5rem',
@@ -52,6 +56,7 @@ const useStyles = makeStyles({
     gridColumn: '1 / 1',
     justifySelf: 'end',
     justifyContent: 'flex-end',
+    alignItems: 'center',
     marginRight: '1rem',
   },
   percentage: {
@@ -73,6 +78,7 @@ export default function ResultsModalOption({
   index,
   accordion,
   yourVote,
+  anonymous,
 }: ResultsModalOptionProps) {
   const classes = useStyles();
   const youVotedFor = yourVote.some((vote: number) => vote === index);
@@ -85,7 +91,7 @@ export default function ResultsModalOption({
           backgroundColor: youVotedFor ? 'rgba(49, 130, 206, 0.75)' : 'rgba(49, 130, 206, 0.20)',
         }}
         className={classes.bar}></div>
-      <div className={classes.leftSide}>
+      <div className={classes.leftSide} style={{ width: anonymous ? '77%' : '70%' }}>
         <div className={classes.optionText}>{result.option}</div>
         {youVotedFor && (
           <div className={classes.checkmark}>

--- a/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/VotePoll/VotePollModalBody.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/PollsWindow/VotePoll/VotePollModalBody.tsx
@@ -28,6 +28,10 @@ const useStyles = makeStyles({
     marginBottom: '2.5rem',
     gap: '0.5rem',
   },
+  optionText: {
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
+  },
   checkmark: {
     marginLeft: '0.5rem',
     display: 'flex',
@@ -142,13 +146,16 @@ export default function VotePollModalBody({
             key={option.id}
             value={option.text}
             variant={option.selected ? 'solid' : 'outline'}
-            height='48px'
+            height='auto'
             width='100%'
             border='4px'
-            style={{ borderRadius: '1rem' }}
+            style={{
+              borderRadius: '1rem',
+              padding: '0.5rem 1rem 0.5rem 1rem',
+            }}
             colorScheme='facebook'
             onClick={() => updateOptions(option.id)}>
-            {option.text}
+            <p className={classes.optionText}>{option.text}</p>
             {option.selected && <Checkmark />}
           </Button>
         ))}


### PR DESCRIPTION
## Visual

https://user-images.githubusercontent.com/61482175/230678634-2ca38fa4-2341-4006-a878-fb8e938d5e4f.mov

## Changes

- in the voting and results modals, allowed the option text to wrap, including text with no spaces (like links) using `overflow-wrap: anywhere`
- made the height of the options dynamic in the voting modal
- added a `margin-right` to the option text in the results modal to prevent it from overlapping with the percentage

(figuring out the CSS took forever 🙃 )
